### PR TITLE
Use multi-stage build in Dockerfile

### DIFF
--- a/autogen/centos-6/Dockerfile
+++ b/autogen/centos-6/Dockerfile
@@ -1,46 +1,44 @@
+FROM centos:6 as builder
+RUN TINI_VERSION="v0.13.2" \
+    && TINI_REAL_VERSION="0.13.2" \
+    && TINI_BUILD="/tmp/tini" \
+    && echo "Installing build dependencies" \
+    && TINI_DEPS="cmake curl gcc git glibc-static libcap-devel make python-devel rpm-build tar" \
+    && yum history new || yum history new \
+    && mv /sbin/weak-modules /sbin/weak-modules.tmp \
+    && yum install --setopt=tsflags=nodocs --assumeyes ${TINI_DEPS} \
+    && echo "Building Tini" \
+    && git clone https://github.com/krallin/tini.git "${TINI_BUILD}" \
+    && cd "${TINI_BUILD}" \
+    && curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz \
+    && tar -xf virtualenv-13.1.2.tar.gz \
+    && mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv \
+    && export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" \
+    && HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" \
+    && HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" \
+    && mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" \
+    && chmod +x "${HARDENING_CHECK_PLACEHOLDER}" \
+    && export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && git checkout "${TINI_VERSION}" \
+    && export SOURCE_DIR="${TINI_BUILD}" \
+    && export BUILD_DIR="${TINI_BUILD}" \
+    && export ARCH_NATIVE=1 \
+    && "${TINI_BUILD}/ci/run_build.sh" \
+    && echo "Move Tini" \
+    && mv "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.rpm" /tmp/tini_release.rpm
 FROM centos:6
-RUN TINI_VERSION="v0.13.2" && \
-    TINI_REAL_VERSION="0.13.2" && \
-    TINI_BUILD="/tmp/tini" && \
-    echo "Installing build dependencies" && \
-    TINI_DEPS="gcc cmake make git rpm-build glibc-static curl tar libcap-devel python-devel" && \
-yum history new || \
-yum history new && \
-mv /sbin/weak-modules /sbin/weak-modules.tmp && \
-yum install --assumeyes ${TINI_DEPS} && \
-    echo "Building Tini" && \
-    git clone https://github.com/krallin/tini.git "${TINI_BUILD}" && \
-cd "${TINI_BUILD}" && \
-curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz && \
-tar -xf virtualenv-13.1.2.tar.gz && \
-mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv && \
-export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" && \
-HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" && \
-HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" && \
-mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" && \
-chmod +x "${HARDENING_CHECK_PLACEHOLDER}" && \
-export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-git checkout "${TINI_VERSION}" && \
-export SOURCE_DIR="${TINI_BUILD}" && \
-export BUILD_DIR="${TINI_BUILD}" && \
-export ARCH_NATIVE=1 && \
-"${TINI_BUILD}/ci/run_build.sh" && \
-    echo "Installing Tini" && \
-    yum install -y "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.rpm" && \
-    echo "Cleaning up" && \
-    cd / && \
-rm -rf "${TINI_BUILD}" && \
-    yum --assumeyes history undo 1 && \
-yum clean all && \
-mv /sbin/weak-modules.tmp /sbin/weak-modules && \
-    echo "Symlinkng to /usr/local/bin" && \
-    ln -s /usr/bin/tini        /usr/local/bin/tini && \
-    ln -s /usr/bin/tini-static /usr/local/bin/tini-static && \
-    echo "Running Smoke Test" && \
-    /usr/bin/tini -- ls && \
-    /usr/bin/tini-static -- ls && \
-    /usr/local/bin/tini -- ls && \
-    /usr/local/bin/tini-static -- ls && \
-    echo "Done"
+COPY --from=builder /tmp/tini_release.rpm /tmp
+RUN yum install -y /tmp/tini_release.rpm \
+    && rm /tmp/tini_release.rpm \
+    && yum clean all \
+    && echo "Symlinkng to /usr/local/bin" \
+    && ln -s /usr/bin/tini        /usr/local/bin/tini \
+    && ln -s /usr/bin/tini-static /usr/local/bin/tini-static \
+    && echo "Running Smoke Test" \
+    && /usr/bin/tini -- ls \
+    && /usr/bin/tini-static -- ls \
+    && /usr/local/bin/tini -- ls \
+    && /usr/local/bin/tini-static -- ls \
+    && echo "Done"
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/autogen/centos-7/Dockerfile
+++ b/autogen/centos-7/Dockerfile
@@ -1,46 +1,44 @@
+FROM centos:7 as builder
+RUN TINI_VERSION="v0.13.2" \
+    && TINI_REAL_VERSION="0.13.2" \
+    && TINI_BUILD="/tmp/tini" \
+    && echo "Installing build dependencies" \
+    && TINI_DEPS="cmake curl gcc git glibc-static libcap-devel make python-devel rpm-build tar" \
+    && yum history new || yum history new \
+    && mv /sbin/weak-modules /sbin/weak-modules.tmp \
+    && yum install --setopt=tsflags=nodocs --assumeyes ${TINI_DEPS} \
+    && echo "Building Tini" \
+    && git clone https://github.com/krallin/tini.git "${TINI_BUILD}" \
+    && cd "${TINI_BUILD}" \
+    && curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz \
+    && tar -xf virtualenv-13.1.2.tar.gz \
+    && mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv \
+    && export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" \
+    && HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" \
+    && HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" \
+    && mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" \
+    && chmod +x "${HARDENING_CHECK_PLACEHOLDER}" \
+    && export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && git checkout "${TINI_VERSION}" \
+    && export SOURCE_DIR="${TINI_BUILD}" \
+    && export BUILD_DIR="${TINI_BUILD}" \
+    && export ARCH_NATIVE=1 \
+    && "${TINI_BUILD}/ci/run_build.sh" \
+    && echo "Move Tini" \
+    && mv "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.rpm" /tmp/tini_release.rpm
 FROM centos:7
-RUN TINI_VERSION="v0.13.2" && \
-    TINI_REAL_VERSION="0.13.2" && \
-    TINI_BUILD="/tmp/tini" && \
-    echo "Installing build dependencies" && \
-    TINI_DEPS="gcc cmake make git rpm-build glibc-static curl tar libcap-devel python-devel" && \
-yum history new || \
-yum history new && \
-mv /sbin/weak-modules /sbin/weak-modules.tmp && \
-yum install --assumeyes ${TINI_DEPS} && \
-    echo "Building Tini" && \
-    git clone https://github.com/krallin/tini.git "${TINI_BUILD}" && \
-cd "${TINI_BUILD}" && \
-curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz && \
-tar -xf virtualenv-13.1.2.tar.gz && \
-mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv && \
-export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" && \
-HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" && \
-HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" && \
-mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" && \
-chmod +x "${HARDENING_CHECK_PLACEHOLDER}" && \
-export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-git checkout "${TINI_VERSION}" && \
-export SOURCE_DIR="${TINI_BUILD}" && \
-export BUILD_DIR="${TINI_BUILD}" && \
-export ARCH_NATIVE=1 && \
-"${TINI_BUILD}/ci/run_build.sh" && \
-    echo "Installing Tini" && \
-    yum install -y "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.rpm" && \
-    echo "Cleaning up" && \
-    cd / && \
-rm -rf "${TINI_BUILD}" && \
-    yum --assumeyes history undo 1 && \
-yum clean all && \
-mv /sbin/weak-modules.tmp /sbin/weak-modules && \
-    echo "Symlinkng to /usr/local/bin" && \
-    ln -s /usr/bin/tini        /usr/local/bin/tini && \
-    ln -s /usr/bin/tini-static /usr/local/bin/tini-static && \
-    echo "Running Smoke Test" && \
-    /usr/bin/tini -- ls && \
-    /usr/bin/tini-static -- ls && \
-    /usr/local/bin/tini -- ls && \
-    /usr/local/bin/tini-static -- ls && \
-    echo "Done"
+COPY --from=builder /tmp/tini_release.rpm /tmp
+RUN yum install -y /tmp/tini_release.rpm \
+    && rm /tmp/tini_release.rpm \
+    && yum clean all \
+    && echo "Symlinkng to /usr/local/bin" \
+    && ln -s /usr/bin/tini        /usr/local/bin/tini \
+    && ln -s /usr/bin/tini-static /usr/local/bin/tini-static \
+    && echo "Running Smoke Test" \
+    && /usr/bin/tini -- ls \
+    && /usr/bin/tini-static -- ls \
+    && /usr/local/bin/tini -- ls \
+    && /usr/local/bin/tini-static -- ls \
+    && echo "Done"
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/autogen/ubuntu-precise/Dockerfile
+++ b/autogen/ubuntu-precise/Dockerfile
@@ -1,44 +1,47 @@
+FROM ubuntu:precise as builder
+RUN TINI_VERSION="v0.13.2" \
+    && TINI_REAL_VERSION="0.13.2" \
+    && TINI_BUILD="/tmp/tini" \
+    && echo "Installing build dependencies" \
+    && TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get update \
+    && apt-get install --yes ${TINI_DEPS} \
+    && echo "Building Tini" \
+    && git clone https://github.com/krallin/tini.git "${TINI_BUILD}" \
+    && cd "${TINI_BUILD}" \
+    && curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz \
+    && tar -xf virtualenv-13.1.2.tar.gz \
+    && mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv \
+    && export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" \
+    && HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" \
+    && HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" \
+    && mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" \
+    && chmod +x "${HARDENING_CHECK_PLACEHOLDER}" \
+    && export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && git checkout "${TINI_VERSION}" \
+    && export SOURCE_DIR="${TINI_BUILD}" \
+    && export BUILD_DIR="${TINI_BUILD}" \
+    && export ARCH_NATIVE=1 \
+    && "${TINI_BUILD}/ci/run_build.sh" \
+    && echo "Move Tini" \
+    && mv "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb" /tmp/tini_release.deb
 FROM ubuntu:precise
-RUN TINI_VERSION="v0.13.2" && \
-    TINI_REAL_VERSION="0.13.2" && \
-    TINI_BUILD="/tmp/tini" && \
-    echo "Installing build dependencies" && \
-    TINI_DEPS="build-essential cmake git rpm curl libcap-dev python-dev hardening-includes" && \
-apt-get update && \
-apt-get install --yes ${TINI_DEPS} && \
-    echo "Building Tini" && \
-    git clone https://github.com/krallin/tini.git "${TINI_BUILD}" && \
-cd "${TINI_BUILD}" && \
-curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz && \
-tar -xf virtualenv-13.1.2.tar.gz && \
-mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv && \
-export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" && \
-HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" && \
-HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" && \
-mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" && \
-chmod +x "${HARDENING_CHECK_PLACEHOLDER}" && \
-export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-git checkout "${TINI_VERSION}" && \
-export SOURCE_DIR="${TINI_BUILD}" && \
-export BUILD_DIR="${TINI_BUILD}" && \
-export ARCH_NATIVE=1 && \
-"${TINI_BUILD}/ci/run_build.sh" && \
-    echo "Installing Tini" && \
-    dpkg -i "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb"  && \
-    echo "Cleaning up" && \
-    cd / && \
-rm -rf "${TINI_BUILD}" && \
-    apt-get purge --yes ${TINI_DEPS} && \
-apt-get autoremove --yes && \
-rm -rf /var/lib/apt/lists/* && \
-    echo "Symlinkng to /usr/local/bin" && \
-    ln -s /usr/bin/tini        /usr/local/bin/tini && \
-    ln -s /usr/bin/tini-static /usr/local/bin/tini-static && \
-    echo "Running Smoke Test" && \
-    /usr/bin/tini -- ls && \
-    /usr/bin/tini-static -- ls && \
-    /usr/local/bin/tini -- ls && \
-    /usr/local/bin/tini-static -- ls && \
-    echo "Done"
+COPY --from=builder /tmp/tini_release.deb /tmp
+RUN apt-get update \
+    && dpkg --force-all -i /tmp/tini_release.deb \
+    && rm /tmp/tini_release.deb \
+    && TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get purge --yes ${TINI_DEPS} \
+    && apt-get autoremove --yes \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "Symlinkng to /usr/local/bin" \
+    && ln -s /usr/bin/tini        /usr/local/bin/tini \
+    && ln -s /usr/bin/tini-static /usr/local/bin/tini-static \
+    && echo "Running Smoke Test" \
+    && /usr/bin/tini -- ls \
+    && /usr/bin/tini-static -- ls \
+    && /usr/local/bin/tini -- ls \
+    && /usr/local/bin/tini-static -- ls \
+    && echo "Done"
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/autogen/ubuntu-trusty/Dockerfile
+++ b/autogen/ubuntu-trusty/Dockerfile
@@ -1,44 +1,47 @@
+FROM ubuntu:trusty as builder
+RUN TINI_VERSION="v0.13.2" \
+    && TINI_REAL_VERSION="0.13.2" \
+    && TINI_BUILD="/tmp/tini" \
+    && echo "Installing build dependencies" \
+    && TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get update \
+    && apt-get install --yes ${TINI_DEPS} \
+    && echo "Building Tini" \
+    && git clone https://github.com/krallin/tini.git "${TINI_BUILD}" \
+    && cd "${TINI_BUILD}" \
+    && curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz \
+    && tar -xf virtualenv-13.1.2.tar.gz \
+    && mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv \
+    && export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" \
+    && HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" \
+    && HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" \
+    && mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" \
+    && chmod +x "${HARDENING_CHECK_PLACEHOLDER}" \
+    && export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && git checkout "${TINI_VERSION}" \
+    && export SOURCE_DIR="${TINI_BUILD}" \
+    && export BUILD_DIR="${TINI_BUILD}" \
+    && export ARCH_NATIVE=1 \
+    && "${TINI_BUILD}/ci/run_build.sh" \
+    && echo "Move Tini" \
+    && mv "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb" /tmp/tini_release.deb
 FROM ubuntu:trusty
-RUN TINI_VERSION="v0.13.2" && \
-    TINI_REAL_VERSION="0.13.2" && \
-    TINI_BUILD="/tmp/tini" && \
-    echo "Installing build dependencies" && \
-    TINI_DEPS="build-essential cmake git rpm curl libcap-dev python-dev hardening-includes" && \
-apt-get update && \
-apt-get install --yes ${TINI_DEPS} && \
-    echo "Building Tini" && \
-    git clone https://github.com/krallin/tini.git "${TINI_BUILD}" && \
-cd "${TINI_BUILD}" && \
-curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz && \
-tar -xf virtualenv-13.1.2.tar.gz && \
-mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv && \
-export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" && \
-HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" && \
-HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" && \
-mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" && \
-chmod +x "${HARDENING_CHECK_PLACEHOLDER}" && \
-export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-git checkout "${TINI_VERSION}" && \
-export SOURCE_DIR="${TINI_BUILD}" && \
-export BUILD_DIR="${TINI_BUILD}" && \
-export ARCH_NATIVE=1 && \
-"${TINI_BUILD}/ci/run_build.sh" && \
-    echo "Installing Tini" && \
-    dpkg -i "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb"  && \
-    echo "Cleaning up" && \
-    cd / && \
-rm -rf "${TINI_BUILD}" && \
-    apt-get purge --yes ${TINI_DEPS} && \
-apt-get autoremove --yes && \
-rm -rf /var/lib/apt/lists/* && \
-    echo "Symlinkng to /usr/local/bin" && \
-    ln -s /usr/bin/tini        /usr/local/bin/tini && \
-    ln -s /usr/bin/tini-static /usr/local/bin/tini-static && \
-    echo "Running Smoke Test" && \
-    /usr/bin/tini -- ls && \
-    /usr/bin/tini-static -- ls && \
-    /usr/local/bin/tini -- ls && \
-    /usr/local/bin/tini-static -- ls && \
-    echo "Done"
+COPY --from=builder /tmp/tini_release.deb /tmp
+RUN apt-get update \
+    && dpkg --force-all -i /tmp/tini_release.deb \
+    && rm /tmp/tini_release.deb \
+    && TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get purge --yes ${TINI_DEPS} \
+    && apt-get autoremove --yes \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "Symlinkng to /usr/local/bin" \
+    && ln -s /usr/bin/tini        /usr/local/bin/tini \
+    && ln -s /usr/bin/tini-static /usr/local/bin/tini-static \
+    && echo "Running Smoke Test" \
+    && /usr/bin/tini -- ls \
+    && /usr/bin/tini-static -- ls \
+    && /usr/local/bin/tini -- ls \
+    && /usr/local/bin/tini-static -- ls \
+    && echo "Done"
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/autogen/ubuntu-xenial/Dockerfile
+++ b/autogen/ubuntu-xenial/Dockerfile
@@ -1,44 +1,47 @@
+FROM ubuntu:xenial as builder
+RUN TINI_VERSION="v0.13.2" \
+    && TINI_REAL_VERSION="0.13.2" \
+    && TINI_BUILD="/tmp/tini" \
+    && echo "Installing build dependencies" \
+    && TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get update \
+    && apt-get install --yes ${TINI_DEPS} \
+    && echo "Building Tini" \
+    && git clone https://github.com/krallin/tini.git "${TINI_BUILD}" \
+    && cd "${TINI_BUILD}" \
+    && curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz \
+    && tar -xf virtualenv-13.1.2.tar.gz \
+    && mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv \
+    && export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" \
+    && HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" \
+    && HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" \
+    && mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" \
+    && chmod +x "${HARDENING_CHECK_PLACEHOLDER}" \
+    && export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && git checkout "${TINI_VERSION}" \
+    && export SOURCE_DIR="${TINI_BUILD}" \
+    && export BUILD_DIR="${TINI_BUILD}" \
+    && export ARCH_NATIVE=1 \
+    && "${TINI_BUILD}/ci/run_build.sh" \
+    && echo "Move Tini" \
+    && mv "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb" /tmp/tini_release.deb
 FROM ubuntu:xenial
-RUN TINI_VERSION="v0.13.2" && \
-    TINI_REAL_VERSION="0.13.2" && \
-    TINI_BUILD="/tmp/tini" && \
-    echo "Installing build dependencies" && \
-    TINI_DEPS="build-essential cmake git rpm curl libcap-dev python-dev hardening-includes" && \
-apt-get update && \
-apt-get install --yes ${TINI_DEPS} && \
-    echo "Building Tini" && \
-    git clone https://github.com/krallin/tini.git "${TINI_BUILD}" && \
-cd "${TINI_BUILD}" && \
-curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz && \
-tar -xf virtualenv-13.1.2.tar.gz && \
-mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv && \
-export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" && \
-HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" && \
-HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" && \
-mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" && \
-chmod +x "${HARDENING_CHECK_PLACEHOLDER}" && \
-export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-git checkout "${TINI_VERSION}" && \
-export SOURCE_DIR="${TINI_BUILD}" && \
-export BUILD_DIR="${TINI_BUILD}" && \
-export ARCH_NATIVE=1 && \
-"${TINI_BUILD}/ci/run_build.sh" && \
-    echo "Installing Tini" && \
-    dpkg -i "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb"  && \
-    echo "Cleaning up" && \
-    cd / && \
-rm -rf "${TINI_BUILD}" && \
-    apt-get purge --yes ${TINI_DEPS} && \
-apt-get autoremove --yes && \
-rm -rf /var/lib/apt/lists/* && \
-    echo "Symlinkng to /usr/local/bin" && \
-    ln -s /usr/bin/tini        /usr/local/bin/tini && \
-    ln -s /usr/bin/tini-static /usr/local/bin/tini-static && \
-    echo "Running Smoke Test" && \
-    /usr/bin/tini -- ls && \
-    /usr/bin/tini-static -- ls && \
-    /usr/local/bin/tini -- ls && \
-    /usr/local/bin/tini-static -- ls && \
-    echo "Done"
+COPY --from=builder /tmp/tini_release.deb /tmp
+RUN apt-get update \
+    && dpkg --force-all -i /tmp/tini_release.deb \
+    && rm /tmp/tini_release.deb \
+    && TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get purge --yes ${TINI_DEPS} \
+    && apt-get autoremove --yes \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "Symlinkng to /usr/local/bin" \
+    && ln -s /usr/bin/tini        /usr/local/bin/tini \
+    && ln -s /usr/bin/tini-static /usr/local/bin/tini-static \
+    && echo "Running Smoke Test" \
+    && /usr/bin/tini -- ls \
+    && /usr/bin/tini-static -- ls \
+    && /usr/local/bin/tini -- ls \
+    && /usr/local/bin/tini-static -- ls \
+    && echo "Done"
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/src/Dockerfile.in
+++ b/src/Dockerfile.in
@@ -1,25 +1,29 @@
+FROM __SOURCE_IMAGE__ as builder
+
+RUN TINI_VERSION="__TINI_VERSION__" \
+    && TINI_REAL_VERSION="__TINI_REAL_VERSION__" \
+    && TINI_BUILD="/tmp/tini" \
+    && echo "Installing build dependencies" \
+    __TINI_INSTALL_DEPS__
+    && echo "Building Tini" \
+    __TINI_BUILD_APP__
+    && echo "Move Tini" \
+    __TINI_MOVE_APP__
+
 FROM __SOURCE_IMAGE__
 
-RUN TINI_VERSION="__TINI_VERSION__" && \
-    TINI_REAL_VERSION="__TINI_REAL_VERSION__" && \
-    TINI_BUILD="/tmp/tini" && \
-    echo "Installing build dependencies" && \
-    __TINI_INSTALL_DEPS__
-    echo "Building Tini" && \
-    __TINI_BUILD_APP__
-    echo "Installing Tini" && \
-    __TINI_INSTALL_APP__
-    echo "Cleaning up" && \
-    __TINI_CLEANUP_APP__
+COPY __TINI_COPY_APP__
+RUN __TINI_INSTALL_APP__
+    __TINI_CLEAN_APP__
     __TINI_CLEANUP_DEPS__
-    echo "Symlinkng to /usr/local/bin" && \
-    ln -s /usr/bin/tini        /usr/local/bin/tini && \
-    ln -s /usr/bin/tini-static /usr/local/bin/tini-static && \
-    echo "Running Smoke Test" && \
-    /usr/bin/tini -- ls && \
-    /usr/bin/tini-static -- ls && \
-    /usr/local/bin/tini -- ls && \
-    /usr/local/bin/tini-static -- ls && \
-    echo "Done"
+    && echo "Symlinkng to /usr/local/bin" \
+    && ln -s /usr/bin/tini        /usr/local/bin/tini \
+    && ln -s /usr/bin/tini-static /usr/local/bin/tini-static \
+    && echo "Running Smoke Test" \
+    && /usr/bin/tini -- ls \
+    && /usr/bin/tini-static -- ls \
+    && /usr/local/bin/tini -- ls \
+    && /usr/local/bin/tini-static -- ls \
+    && echo "Done"
 
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/src/autogen.sh
+++ b/src/autogen.sh
@@ -34,12 +34,14 @@ for dir in "platform/"*; do
     perl -pe "s/__TINI_REAL_VERSION__/'${TINI_REAL_VERSION}'/ge" -i "${dockerfile}"
 
     perl -pe 's/__TINI_BUILD_APP__/`cat build-app`/ge' -i "${dockerfile}"
-    perl -pe 's/__TINI_CLEANUP_APP__/`cat cleanup-app`/ge' -i "${dockerfile}"
 
     pushd "${HERE}/platform/${platform}" >/dev/null
     perl -pe 's/__TINI_INSTALL_APP__/`cat install-app`/ge' -i "${dockerfile}"
     perl -pe 's/__TINI_INSTALL_DEPS__/`cat install-deps`/ge' -i "${dockerfile}"
     perl -pe 's/__TINI_CLEANUP_DEPS__/`cat cleanup-deps`/ge' -i "${dockerfile}"
+    perl -pe 's/__TINI_MOVE_APP__/`cat move-app`/ge' -i "${dockerfile}"
+    perl -pe 's/__TINI_COPY_APP__/`cat copy-app`/ge' -i "${dockerfile}"
+    perl -pe 's/__TINI_CLEAN_APP__/`cat clean-app`/ge' -i "${dockerfile}"
     popd >/dev/null
 
     perl -n -e 'print if /\S/' -i "${dockerfile}"

--- a/src/build-app
+++ b/src/build-app
@@ -1,17 +1,17 @@
-git clone https://github.com/krallin/tini.git "${TINI_BUILD}" && \
-cd "${TINI_BUILD}" && \
-curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz && \
-tar -xf virtualenv-13.1.2.tar.gz && \
-mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv && \
-export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" && \
-HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" && \
-HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" && \
-mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" && \
-chmod +x "${HARDENING_CHECK_PLACEHOLDER}" && \
-export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" && \
-git checkout "${TINI_VERSION}" && \
-export SOURCE_DIR="${TINI_BUILD}" && \
-export BUILD_DIR="${TINI_BUILD}" && \
-export ARCH_NATIVE=1 && \
-"${TINI_BUILD}/ci/run_build.sh" && \
+&& git clone https://github.com/krallin/tini.git "${TINI_BUILD}" \
+    && cd "${TINI_BUILD}" \
+    && curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz \
+    && tar -xf virtualenv-13.1.2.tar.gz \
+    && mv virtualenv-13.1.2/virtualenv.py virtualenv-13.1.2/virtualenv \
+    && export PATH="${TINI_BUILD}/virtualenv-13.1.2:${PATH}" \
+    && HARDENING_CHECK_PLACEHOLDER="${TINI_BUILD}/hardening-check/hardening-check" \
+    && HARDENING_CHECK_PLACEHOLDER_DIR="$(dirname "${HARDENING_CHECK_PLACEHOLDER}")" \
+    && mkdir "${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && echo  "#/bin/sh" > "${HARDENING_CHECK_PLACEHOLDER}" \
+    && chmod +x "${HARDENING_CHECK_PLACEHOLDER}" \
+    && export PATH="${PATH}:${HARDENING_CHECK_PLACEHOLDER_DIR}" \
+    && git checkout "${TINI_VERSION}" \
+    && export SOURCE_DIR="${TINI_BUILD}" \
+    && export BUILD_DIR="${TINI_BUILD}" \
+    && export ARCH_NATIVE=1 \
+    && "${TINI_BUILD}/ci/run_build.sh" \

--- a/src/cleanup-app
+++ b/src/cleanup-app
@@ -1,2 +1,0 @@
-cd / && \
-rm -rf "${TINI_BUILD}" && \

--- a/src/platform/centos/clean-app
+++ b/src/platform/centos/clean-app
@@ -1,0 +1,1 @@
+&& rm /tmp/tini_release.rpm \

--- a/src/platform/centos/cleanup-deps
+++ b/src/platform/centos/cleanup-deps
@@ -1,3 +1,1 @@
-yum --assumeyes history undo 1 && \
-yum clean all && \
-mv /sbin/weak-modules.tmp /sbin/weak-modules && \
+&& yum clean all \

--- a/src/platform/centos/copy-app
+++ b/src/platform/centos/copy-app
@@ -1,0 +1,1 @@
+--from=builder /tmp/tini_release.rpm /tmp

--- a/src/platform/centos/install-app
+++ b/src/platform/centos/install-app
@@ -1,1 +1,1 @@
-yum install -y "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.rpm" && \
+yum install -y /tmp/tini_release.rpm \

--- a/src/platform/centos/install-deps
+++ b/src/platform/centos/install-deps
@@ -1,5 +1,4 @@
-TINI_DEPS="gcc cmake make git rpm-build glibc-static curl tar libcap-devel python-devel" && \
-yum history new || \
-yum history new && \
-mv /sbin/weak-modules /sbin/weak-modules.tmp && \
-yum install --assumeyes ${TINI_DEPS} && \
+&& TINI_DEPS="cmake curl gcc git glibc-static libcap-devel make python-devel rpm-build tar" \
+    && yum history new || yum history new \
+    && mv /sbin/weak-modules /sbin/weak-modules.tmp \
+    && yum install --setopt=tsflags=nodocs --assumeyes ${TINI_DEPS} \

--- a/src/platform/centos/move-app
+++ b/src/platform/centos/move-app
@@ -1,0 +1,1 @@
+&& mv "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.rpm" /tmp/tini_release.rpm

--- a/src/platform/ubuntu/clean-app
+++ b/src/platform/ubuntu/clean-app
@@ -1,0 +1,1 @@
+&& rm /tmp/tini_release.deb \

--- a/src/platform/ubuntu/cleanup-deps
+++ b/src/platform/ubuntu/cleanup-deps
@@ -1,3 +1,4 @@
-apt-get purge --yes ${TINI_DEPS} && \
-apt-get autoremove --yes && \
-rm -rf /var/lib/apt/lists/* && \
+&& TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get purge --yes ${TINI_DEPS} \
+    && apt-get autoremove --yes \
+    && rm -rf /var/lib/apt/lists/* \

--- a/src/platform/ubuntu/copy-app
+++ b/src/platform/ubuntu/copy-app
@@ -1,0 +1,1 @@
+--from=builder /tmp/tini_release.deb /tmp

--- a/src/platform/ubuntu/install-app
+++ b/src/platform/ubuntu/install-app
@@ -1,1 +1,3 @@
-dpkg -i "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb"  && \
+apt-get update \
+    && dpkg --force-all -i /tmp/tini_release.deb \
+

--- a/src/platform/ubuntu/install-deps
+++ b/src/platform/ubuntu/install-deps
@@ -1,3 +1,3 @@
-TINI_DEPS="build-essential cmake git rpm curl libcap-dev python-dev hardening-includes" && \
-apt-get update && \
-apt-get install --yes ${TINI_DEPS} && \
+&& TINI_DEPS="build-essential cmake curl git hardening-includes libcap-dev python-dev rpm" \
+    && apt-get update \
+    && apt-get install --yes ${TINI_DEPS} \

--- a/src/platform/ubuntu/move-app
+++ b/src/platform/ubuntu/move-app
@@ -1,0 +1,1 @@
+&& mv "${TINI_BUILD}/tini_${TINI_REAL_VERSION}.deb" /tmp/tini_release.deb


### PR DESCRIPTION
Result images are smaller and cleaner, no trace of build phase and respects the [Dockerfile best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).